### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ Works cross-realm/iframe and despite `Symbol.toStringTag`.
 npm install isurl
 ```
 
+## Importing
+
+```js
+import isURL from 'isurl'; // ES6
+const isURL = require('isurl'); // ES5 with npm
+```
 
 ## Usage
 
 ```js
-const isURL = require('isurl');
-
 isURL('http://domain/');  //-> false
 isURL(new URL('http://domain/'));  //-> true
 ```


### PR DESCRIPTION
Less experienced users sometimes get confused by the different module importing syntax.

As JavaScript has now a standard module importing syntax defined by TC39 it makes sense to show the ES6 import as the default one and the CommonJS one as a fallback for users writing ES5.

Also *Importing* is now split from *Usage* in the docs for additional clarity.

: https://tc39.github.io/ecma262/#sec-imports