### PR TITLE
Inlining is-object dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 "use strict";
 const hasToStringTag = require("has-to-string-tag-x");
-const isObject = require("is-object");
 const isURLSearchParams = require("is-urlsearchparams");
 const {lenientProperties, strictProperties} = require("./props");
 
@@ -12,7 +11,7 @@ const urlClass = "[object URL]";
 
 const isURL = (url, supportIncomplete=false) =>
 {
-	if (!isObject(url))
+	if (typeof url !== 'object' || url === null)
 	{
 		return false;
 	}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "browser": "lib-es5",
   "dependencies": {
     "has-to-string-tag-x": "^1.4.1",
-    "is-object": "^1.0.1",
     "is-urlsearchparams": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Given the popularity of this pacakge, I thought it migth be helpful to
remove a 1-liner depedencency. Saves a tiny bit of time everywhere, and
perhaps promotes the idea that throwaway npm dependencies aren't all
that necessary.

I understand and will not be offended if this goes against philosophy.
We're cool.

If it is accepted I will propose the same change on
`is-urlsearchparams`.